### PR TITLE
feat(blogs): add Google Interview Experience article to blogs section…

### DIFF
--- a/pages/blogs/index.js
+++ b/pages/blogs/index.js
@@ -4,6 +4,13 @@ import Header from "../../components/Header";
 
 const blogs = [
   {
+    title: "My Google Interview Experience for SWE-2 (L3) Position",
+    date: "Sept 28, 2025",
+    description:
+      "Detailed my preparation journey, interview process, and final selection at Google for the SWE-2 (L3) position.",
+    link: "https://medium.com/@kaustubhdwivedi1729/google-interview-experience-for-swe-2-l3-position-selected-ea71270c8133",
+  },
+  {
     title: "Converting Epoch Time to System Local Time",
     date: "04 April, 2024",
     description: 


### PR DESCRIPTION
… (#5)
## Description
This PR adds the **Google Interview Experience** article by @kd1729 to the Blogs section (`pages/blogs/index.jsx`).  
The blog is now included alongside existing entries and links directly to the Medium article.

## Issue

Closes #5 

---

## Changes Made
- Updated `pages/blogs/index.jsx`:
  - Added new blog entry:
    - **Title**: "Google Interview Experience for SWE-2 (L3) Position"
    - **Description**: Covers preparation, interview process, and final selection at Google.
    - **Link**: [Medium Article](https://medium.com/@kaustubhdwivedi1729/google-interview-experience-for-swe-2-l3-position-selected-ea71270c8133)
    - **Date**: `Sept 28, 2025`
  - Preserved chronological order and consistent formatting with existing blogs.

---
